### PR TITLE
fix: realtime simulator cron requests

### DIFF
--- a/supabase/migrations/20250108000002_setup_cron_jobs.sql
+++ b/supabase/migrations/20250108000002_setup_cron_jobs.sql
@@ -6,10 +6,23 @@ SELECT cron.schedule(
   'capacity-violation-detector',
   '*/3 * * * *', -- Every 3 minutes
   $$
+  WITH secret as (
+      select decrypted_secret AS supabase_anon_key
+      from vault.decrypted_secrets
+      where name = 'supabase_anon_key'
+  ),
+  settings AS (
+      select decrypted_secret AS supabase_url
+      from vault.decrypted_secrets
+      where name = 'supabase_url'
+  )
   SELECT net.http_post(
-    url := 'https://nnipoczsqoylnrwidbgp.supabase.co/functions/v1/capacity-violation-detector',
-    headers := '{"Authorization": "Bearer YOUR_ANON_KEY", "Content-Type": "application/json"}'::jsonb,
-    body := '{}'::jsonb
+      url := (select supabase_url from settings) || '/functions/v1/' || 'capacity-violation-detector',
+      headers := jsonb_build_object(
+          'Authorization', 'Bearer ' || (select supabase_anon_key from secret),
+          'Content-Type', 'application/json'
+      ),
+      body := '{}'::jsonb
   );
   $$
 );
@@ -20,10 +33,23 @@ SELECT cron.schedule(
   'sensor-data-simulator',
   '* * * * *', -- Every minute
   $$
+  WITH secret as (
+      select decrypted_secret AS supabase_anon_key
+      from vault.decrypted_secrets
+      where name = 'supabase_anon_key'
+  ),
+  settings AS (
+      select decrypted_secret AS supabase_url
+      from vault.decrypted_secrets
+      where name = 'supabase_url'
+  )
   SELECT net.http_post(
-    url := 'https://nnipoczsqoylnrwidbgp.supabase.co/functions/v1/sensor-data-simulator',
-    headers := '{"Authorization": "Bearer YOUR_ANON_KEY", "Content-Type": "application/json"}'::jsonb,
-    body := '{}'::jsonb
+      url := (select supabase_url from settings) || '/functions/v1/' || 'sensor-data-simulator',
+      headers := jsonb_build_object(
+          'Authorization', 'Bearer ' || (select supabase_anon_key from secret),
+          'Content-Type', 'application/json'
+      ),
+      body := '{}'::jsonb
   );
   $$
 );
@@ -34,10 +60,23 @@ SELECT cron.schedule(
   'room-booking-simulator',
   '*/90 * * * *', -- Every 90 minutes
   $$
+  WITH secret as (
+      select decrypted_secret AS supabase_anon_key
+      from vault.decrypted_secrets
+      where name = 'supabase_anon_key'
+  ),
+  settings AS (
+      select decrypted_secret AS supabase_url
+      from vault.decrypted_secrets
+      where name = 'supabase_url'
+  )
   SELECT net.http_post(
-    url := 'https://nnipoczsqoylnrwidbgp.supabase.co/functions/v1/room-booking-simulator',
-    headers := '{"Authorization": "Bearer YOUR_ANON_KEY", "Content-Type": "application/json"}'::jsonb,
-    body := '{}'::jsonb
+      url := (select supabase_url from settings) || '/functions/v1/' || 'room-booking-simulator',
+      headers := jsonb_build_object(
+          'Authorization', 'Bearer ' || (select supabase_anon_key from secret),
+          'Content-Type', 'application/json'
+      ),
+      body := '{}'::jsonb
   );
   $$
 );

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -1,0 +1,3 @@
+-- pg_net environment secrets
+select vault.create_secret('http://host.docker.internal:54321', 'supabase_url');
+select vault.create_secret('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0', 'supabase_anon_key');


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Realtime data simulators request to an external project

## What is the new behavior?

Cron jobs now calls based on `vault` variables

## Additional context

You guys may need to update the already migrated crons, 
or just run `supabase db reset` - ⚠️ it requires to generate data again