### PR TITLE
fix: "trigger detection" button

### DIFF
--- a/src/lib/api/alerts.ts
+++ b/src/lib/api/alerts.ts
@@ -143,19 +143,12 @@ export class AlertsApi extends ApiClient {
    */
   async triggerViolationDetection(): Promise<ApiResponse<unknown>> {
     try {
-      const response = await fetch("/api/detect-violations", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-      });
+      const { data, error } = await supabase.functions.invoke('capacity-violation-detector')
 
-      const data = await response.json();
-
-      if (!response.ok) {
+      if (error) {
         return {
           success: false,
-          error: data.error || "Failed to trigger violation detection",
+          error: error || "Failed to trigger violation detection",
         };
       }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

The button calls a wrong api endpoint

<img width="3122" height="940" alt="image" src="https://github.com/user-attachments/assets/9b9d962b-7c00-40a8-ad56-7b527202e913" />

## What is the new behaviour?

Now calls the right edge-function

<details>
<summary>screenshots</summary>

<img width="2484" height="1774" alt="image" src="https://github.com/user-attachments/assets/15868835-8f68-4f2b-8da7-ef5a57fbe27c" />


<img width="1444" height="528" alt="image" src="https://github.com/user-attachments/assets/7ab88efa-3eac-4cdc-9049-0e2521be76b9" />

</details>
